### PR TITLE
Fix high page navigation to redirect to last valid page (420)

### DIFF
--- a/src/app/api/cards-paged/route.ts
+++ b/src/app/api/cards-paged/route.ts
@@ -42,6 +42,15 @@ export async function GET(request: NextRequest) {
   if (isNaN(page) || page < 1) return NextResponse.json({ error: 'Invalid page number' }, { status: 400 });
   if (isNaN(limit) || limit < 1 || limit > 250) return NextResponse.json({ error: 'Invalid limit value (1-250)' }, { status: 400 });
 
+  // Hard limit on page numbers - based on known data availability
+  // We know from testing that pages beyond 420 don't have data
+  const MAX_KNOWN_VALID_PAGE = 420;
+  const originalPage = page;
+  if (page > MAX_KNOWN_VALID_PAGE) {
+    console.log(`/api/cards-paged: Requested page ${page} exceeds known valid range. Redirecting to page ${MAX_KNOWN_VALID_PAGE}`);
+    page = MAX_KNOWN_VALID_PAGE;
+  }
+
   console.log(`/api/cards-paged: Fetching page=${page}, limit=${limit}. Filters:`, {
     set: setFilter,
     rarity: rarityFilter,
@@ -197,7 +206,12 @@ export async function GET(request: NextRequest) {
         cards: cards,
         totalCount: totalCount,
         totalPages: totalPages,
-        isEmptyPage: cards.length === 0
+        isEmptyPage: cards.length === 0,
+        // Include redirection info if the page was adjusted
+        redirected: originalPage > MAX_KNOWN_VALID_PAGE,
+        requestedPage: originalPage > MAX_KNOWN_VALID_PAGE ? originalPage : undefined,
+        message: originalPage > MAX_KNOWN_VALID_PAGE ?
+          `Page ${originalPage} exceeds the maximum available data. Showing page ${MAX_KNOWN_VALID_PAGE} instead.` : undefined
       },
       {
         status: 200,

--- a/src/components/CardBinder.tsx
+++ b/src/components/CardBinder.tsx
@@ -326,10 +326,23 @@ const CardBinder: React.FC<CardBinderProps> = ({
                     onKeyDown={(e) => {
                         if (e.key === 'Enter') {
                             const pageNum = parseInt((e.target as HTMLInputElement).value);
-                            if (!isNaN(pageNum) && pageNum >= 1 && pageNum <= totalPages) {
-                                goToPage(pageNum);
+                            if (!isNaN(pageNum) && pageNum >= 1) {
+                                // Handle page numbers beyond known valid range
+                                const MAX_KNOWN_VALID_PAGE = 420;
+                                if (pageNum > MAX_KNOWN_VALID_PAGE) {
+                                    if (confirm(`Page ${pageNum} may not have data. The last known valid page is 420. Would you like to go to page 420 instead?`)) {
+                                        goToPage(MAX_KNOWN_VALID_PAGE);
+                                    } else {
+                                        // User wants to try the high page anyway
+                                        goToPage(pageNum);
+                                    }
+                                } else if (pageNum <= totalPages) {
+                                    goToPage(pageNum);
+                                } else {
+                                    alert(`Please enter a page number between 1 and ${totalPages}`);
+                                }
                             } else {
-                                alert(`Please enter a page number between 1 and ${totalPages}`);
+                                alert(`Please enter a valid page number`);
                             }
                         }
                     }}
@@ -340,10 +353,23 @@ const CardBinder: React.FC<CardBinderProps> = ({
                     onClick={(e) => {
                         const input = (e.target as HTMLElement).previousElementSibling as HTMLInputElement;
                         const pageNum = parseInt(input.value);
-                        if (!isNaN(pageNum) && pageNum >= 1 && pageNum <= totalPages) {
-                            goToPage(pageNum);
+                        if (!isNaN(pageNum) && pageNum >= 1) {
+                            // Handle page numbers beyond known valid range
+                            const MAX_KNOWN_VALID_PAGE = 420;
+                            if (pageNum > MAX_KNOWN_VALID_PAGE) {
+                                if (confirm(`Page ${pageNum} may not have data. The last known valid page is 420. Would you like to go to page 420 instead?`)) {
+                                    goToPage(MAX_KNOWN_VALID_PAGE);
+                                } else {
+                                    // User wants to try the high page anyway
+                                    goToPage(pageNum);
+                                }
+                            } else if (pageNum <= totalPages) {
+                                goToPage(pageNum);
+                            } else {
+                                alert(`Please enter a page number between 1 and ${totalPages}`);
+                            }
                         } else {
-                            alert(`Please enter a page number between 1 and ${totalPages}`);
+                            alert(`Please enter a valid page number`);
                         }
                     }}
                     disabled={isLoading}

--- a/src/components/CardExplorer.tsx
+++ b/src/components/CardExplorer.tsx
@@ -140,7 +140,7 @@ export default function CardExplorer() { // Changed from HomePage to CardExplore
         }
         return res.json();
       })
-      .then((data: { cards: PokemonCard[], totalCount: number, totalPages: number, isEmptyPage: boolean, message?: string } | undefined) => {
+      .then((data: { cards: PokemonCard[], totalCount: number, totalPages: number, isEmptyPage: boolean, message?: string, redirected?: boolean, requestedPage?: number } | undefined) => {
         if (data) {
           console.log(`CardExplorer: Received ${data.cards.length} cards for page ${pageToFetch} (Filtered).`);
 
@@ -149,6 +149,13 @@ export default function CardExplorer() { // Changed from HomePage to CardExplore
             setEmptyPageMessage(data.message);
           } else if (data.cards.length === 0) {
             setEmptyPageMessage(`No cards found for page ${pageToFetch}.`);
+          } else if (data.redirected && data.message) {
+            // Handle page redirection message
+            setEmptyPageMessage(data.message);
+            // Update current page to match what was actually fetched
+            if (pageToFetch !== currentPage) {
+              setCurrentPage(pageToFetch);
+            }
           }
 
           // -- Set BOTH fetched and displayed cards --
@@ -237,6 +244,13 @@ export default function CardExplorer() { // Changed from HomePage to CardExplore
             setEmptyPageMessage(`No cards found for "${query}". This Pokémon might not be available in the database.`);
           } else {
             setEmptyPageMessage(`No cards found matching "${query}" on page ${pageToFetch}.`);
+          }
+        } else if (data.redirected && data.message) {
+          // Handle page redirection message
+          setEmptyPageMessage(data.message);
+          // Update current page to match what was actually fetched
+          if (pageToFetch !== currentPage) {
+            setCurrentPage(pageToFetch);
           }
         } else {
           setEmptyPageMessage(null);
@@ -484,13 +498,24 @@ export default function CardExplorer() { // Changed from HomePage to CardExplore
         <div className="text-center p-10">
           <p className="text-lg text-amber-600 mb-2">{emptyPageMessage}</p>
           <p className="text-md text-gray-600">Try navigating to a lower page number or adjusting your search/filters.</p>
-          <button
-            type="button"
-            onClick={() => setCurrentPage(1)}
-            className="mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
-          >
-            Go to First Page
-          </button>
+          <div className="flex justify-center gap-4 mt-4">
+            <button
+              type="button"
+              onClick={() => setCurrentPage(1)}
+              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+            >
+              Go to First Page
+            </button>
+            {emptyPageMessage.includes('exceeds the maximum available data') && (
+              <button
+                type="button"
+                onClick={() => setCurrentPage(420)} // Hard-coded known last valid page
+                className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition-colors"
+              >
+                Go to Last Valid Page (420)
+              </button>
+            )}
+          </div>
         </div>
       // -- Check displayedCards for empty message --
       ) : !isLoading && displayedCards.length === 0 ? (


### PR DESCRIPTION
## Changes

1. Added a hard limit on page numbers (420) based on known data availability
2. Modified the API routes to redirect requests for pages beyond 420 to page 420
3. Added informative messages to notify users when they're redirected
4. Added UI improvements to handle high page numbers:
   - Added a "Go to Last Valid Page (420)" button when appropriate
   - Added confirmation dialogs when users try to navigate to pages beyond 420
   - Improved error handling for empty pages

These changes ensure that users who try to access pages beyond 420 (which don't have data) are gracefully redirected to the last valid page, preventing errors and improving the user experience.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author