### PR TITLE
Add local data caching and download scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
   "private": true,
   "scripts": {
     "dev": "next dev -H 0.0.0.0",
-    "build": "next build",
+    "download-data": "node scripts/download-pokemon-data.js",
+    "download-images": "node scripts/download-pokemon-images.js",
+    "download-all": "npm run download-data && npm run download-images",
+    "build": "npm run download-data && next build",
     "start": "next start",
     "lint": "next lint",
-    "export": "next build",
+    "export": "npm run download-all && next build",
     "update-github-data": "ts-node --project tsconfig.json src/scripts/updateGithubData.ts"
   },
   "dependencies": {

--- a/scripts/download-pokemon-data.js
+++ b/scripts/download-pokemon-data.js
@@ -1,0 +1,158 @@
+/**
+ * Download Pokemon TCG data from GitHub
+ * This script downloads all sets and cards data from the Pokemon TCG GitHub repository
+ * and saves them to the public/data directory for local access.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const { promisify } = require('util');
+
+// GitHub repository information
+const GITHUB_REPO = 'PokemonTCG/pokemon-tcg-data';
+const GITHUB_BRANCH = 'master';
+const GITHUB_RAW_URL = `https://raw.githubusercontent.com/${GITHUB_REPO}/${GITHUB_BRANCH}`;
+
+// Local directories
+const DATA_DIR = path.join(process.cwd(), 'public', 'data');
+const SETS_DIR = path.join(DATA_DIR, 'sets');
+const CARDS_DIR = path.join(DATA_DIR, 'cards');
+
+// Create directories if they don't exist
+function ensureDirectoryExists(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+    console.log(`Created directory: ${dir}`);
+  }
+}
+
+// Download a file from a URL
+async function downloadFile(url, outputPath) {
+  return new Promise((resolve, reject) => {
+    console.log(`Downloading ${url} to ${outputPath}...`);
+    
+    const file = fs.createWriteStream(outputPath);
+    
+    https.get(url, (response) => {
+      if (response.statusCode !== 200) {
+        reject(new Error(`Failed to download ${url}: ${response.statusCode} ${response.statusMessage}`));
+        return;
+      }
+      
+      response.pipe(file);
+      
+      file.on('finish', () => {
+        file.close();
+        console.log(`Downloaded ${url} to ${outputPath}`);
+        resolve();
+      });
+    }).on('error', (err) => {
+      fs.unlink(outputPath, () => {}); // Delete the file if there was an error
+      reject(err);
+    });
+  });
+}
+
+// Download sets data
+async function downloadSets() {
+  ensureDirectoryExists(SETS_DIR);
+  
+  const setsUrl = `${GITHUB_RAW_URL}/sets/en.json`;
+  const setsOutputPath = path.join(SETS_DIR, 'sets.json');
+  
+  await downloadFile(setsUrl, setsOutputPath);
+  
+  // Read the sets file to get the list of sets
+  const setsData = JSON.parse(fs.readFileSync(setsOutputPath, 'utf8'));
+  console.log(`Downloaded ${setsData.length} sets`);
+  
+  return setsData;
+}
+
+// Download cards data for a set
+async function downloadCardsForSet(setId) {
+  const cardsUrl = `${GITHUB_RAW_URL}/cards/${setId}/en.json`;
+  const cardsOutputPath = path.join(CARDS_DIR, `${setId}.json`);
+  
+  try {
+    await downloadFile(cardsUrl, cardsOutputPath);
+    
+    // Read the cards file to get the count
+    const cardsData = JSON.parse(fs.readFileSync(cardsOutputPath, 'utf8'));
+    console.log(`Downloaded ${cardsData.length} cards for set ${setId}`);
+    
+    return cardsData.length;
+  } catch (error) {
+    console.error(`Error downloading cards for set ${setId}:`, error.message);
+    return 0;
+  }
+}
+
+// Main function
+async function main() {
+  console.log('Starting Pokemon TCG data download...');
+  
+  ensureDirectoryExists(DATA_DIR);
+  ensureDirectoryExists(CARDS_DIR);
+  
+  try {
+    // Download sets data
+    const sets = await downloadSets();
+    
+    // Download cards data for each set
+    let totalCards = 0;
+    let totalSets = 0;
+    
+    // Process sets in batches to avoid overwhelming the GitHub API
+    const BATCH_SIZE = 5;
+    for (let i = 0; i < sets.length; i += BATCH_SIZE) {
+      const batch = sets.slice(i, i + BATCH_SIZE);
+      
+      // Download cards for each set in the batch in parallel
+      const results = await Promise.all(
+        batch.map(set => downloadCardsForSet(set.id))
+      );
+      
+      // Count the total number of cards downloaded
+      const batchCards = results.reduce((sum, count) => sum + count, 0);
+      totalCards += batchCards;
+      totalSets += batch.length;
+      
+      console.log(`Completed ${totalSets}/${sets.length} sets, ${totalCards} cards so far`);
+      
+      // Add a small delay between batches to avoid rate limiting
+      if (i + BATCH_SIZE < sets.length) {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    }
+    
+    console.log(`Download complete! Downloaded ${totalCards} cards across ${totalSets} sets.`);
+    
+    // Create a metadata file with download information
+    const metadata = {
+      downloadedAt: new Date().toISOString(),
+      totalSets,
+      totalCards,
+      sets: sets.map(set => ({
+        id: set.id,
+        name: set.name,
+        releaseDate: set.releaseDate
+      }))
+    };
+    
+    fs.writeFileSync(
+      path.join(DATA_DIR, 'metadata.json'),
+      JSON.stringify(metadata, null, 2)
+    );
+    
+    console.log('Created metadata file');
+    
+  } catch (error) {
+    console.error('Error downloading Pokemon TCG data:', error);
+    process.exit(1);
+  }
+}
+
+// Run the main function
+main();

--- a/scripts/download-pokemon-images.js
+++ b/scripts/download-pokemon-images.js
@@ -1,0 +1,174 @@
+/**
+ * Download Pokemon TCG card images
+ * This script downloads card images for the most recent sets to provide initial caching
+ */
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const { promisify } = require('util');
+
+// Local directories
+const DATA_DIR = path.join(process.cwd(), 'public', 'data');
+const SETS_DIR = path.join(DATA_DIR, 'sets');
+const CARDS_DIR = path.join(DATA_DIR, 'cards');
+const IMAGES_DIR = path.join(process.cwd(), 'public', 'images', 'cards');
+
+// Number of recent sets to download images for
+const RECENT_SETS_COUNT = 5;
+
+// Create directories if they don't exist
+function ensureDirectoryExists(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+    console.log(`Created directory: ${dir}`);
+  }
+}
+
+// Download an image from a URL
+async function downloadImage(url, outputPath) {
+  return new Promise((resolve, reject) => {
+    // Skip if the file already exists
+    if (fs.existsSync(outputPath)) {
+      console.log(`Image already exists: ${outputPath}`);
+      resolve();
+      return;
+    }
+    
+    console.log(`Downloading image ${url} to ${outputPath}...`);
+    
+    const file = fs.createWriteStream(outputPath);
+    
+    https.get(url, (response) => {
+      if (response.statusCode !== 200) {
+        reject(new Error(`Failed to download ${url}: ${response.statusCode} ${response.statusMessage}`));
+        return;
+      }
+      
+      response.pipe(file);
+      
+      file.on('finish', () => {
+        file.close();
+        console.log(`Downloaded image ${url} to ${outputPath}`);
+        resolve();
+      });
+    }).on('error', (err) => {
+      fs.unlink(outputPath, () => {}); // Delete the file if there was an error
+      reject(err);
+    });
+  });
+}
+
+// Main function
+async function main() {
+  console.log('Starting Pokemon TCG image download...');
+  
+  ensureDirectoryExists(IMAGES_DIR);
+  
+  try {
+    // Read the sets data
+    const setsPath = path.join(SETS_DIR, 'sets.json');
+    if (!fs.existsSync(setsPath)) {
+      console.error('Sets data not found. Please run download-pokemon-data.js first.');
+      process.exit(1);
+    }
+    
+    const sets = JSON.parse(fs.readFileSync(setsPath, 'utf8'));
+    
+    // Sort sets by release date (newest first)
+    sets.sort((a, b) => new Date(b.releaseDate) - new Date(a.releaseDate));
+    
+    // Get the most recent sets
+    const recentSets = sets.slice(0, RECENT_SETS_COUNT);
+    
+    console.log(`Downloading images for the ${RECENT_SETS_COUNT} most recent sets:`);
+    recentSets.forEach(set => console.log(`- ${set.name} (${set.id})`));
+    
+    let totalImages = 0;
+    let totalDownloaded = 0;
+    
+    // Process each recent set
+    for (const set of recentSets) {
+      const setId = set.id;
+      const cardsPath = path.join(CARDS_DIR, `${setId}.json`);
+      
+      if (!fs.existsSync(cardsPath)) {
+        console.warn(`Cards data for set ${setId} not found. Skipping.`);
+        continue;
+      }
+      
+      const cards = JSON.parse(fs.readFileSync(cardsPath, 'utf8'));
+      console.log(`Processing ${cards.length} cards for set ${setId} (${set.name})...`);
+      
+      // Create a directory for the set
+      const setImagesDir = path.join(IMAGES_DIR, setId);
+      ensureDirectoryExists(setImagesDir);
+      
+      // Process cards in batches to avoid overwhelming the server
+      const BATCH_SIZE = 10;
+      for (let i = 0; i < cards.length; i += BATCH_SIZE) {
+        const batch = cards.slice(i, i + BATCH_SIZE);
+        
+        // Download images for each card in the batch in parallel
+        const promises = batch.map(card => {
+          if (card.images && card.images.small) {
+            totalImages++;
+            
+            // Extract the filename from the URL
+            const urlParts = card.images.small.split('/');
+            const filename = urlParts[urlParts.length - 1];
+            const outputPath = path.join(setImagesDir, filename);
+            
+            return downloadImage(card.images.small, outputPath)
+              .then(() => {
+                totalDownloaded++;
+                return true;
+              })
+              .catch(error => {
+                console.error(`Error downloading image for card ${card.id}:`, error.message);
+                return false;
+              });
+          }
+          return Promise.resolve(false);
+        });
+        
+        await Promise.all(promises);
+        
+        console.log(`Downloaded ${totalDownloaded}/${totalImages} images so far...`);
+        
+        // Add a small delay between batches to avoid rate limiting
+        if (i + BATCH_SIZE < cards.length) {
+          await new Promise(resolve => setTimeout(resolve, 500));
+        }
+      }
+    }
+    
+    console.log(`Image download complete! Downloaded ${totalDownloaded}/${totalImages} images.`);
+    
+    // Create a metadata file with download information
+    const metadata = {
+      downloadedAt: new Date().toISOString(),
+      totalSets: recentSets.length,
+      totalImages: totalDownloaded,
+      sets: recentSets.map(set => ({
+        id: set.id,
+        name: set.name,
+        releaseDate: set.releaseDate
+      }))
+    };
+    
+    fs.writeFileSync(
+      path.join(IMAGES_DIR, 'metadata.json'),
+      JSON.stringify(metadata, null, 2)
+    );
+    
+    console.log('Created images metadata file');
+    
+  } catch (error) {
+    console.error('Error downloading Pokemon TCG images:', error);
+    process.exit(1);
+  }
+}
+
+// Run the main function
+main();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "@/styles/mobile-optimizations.css";
 import Header from "@/components/Header";
 import MobileNavigation from "@/components/MobileNavigation";
 import ApiKeyVerifier from "@/components/ApiKeyVerifier";
+import DataSourceStatus from "@/components/DataSourceStatus";
 import { CollectionProvider } from "@/context/CollectionContext";
 import { AuthProvider } from "@/context/AuthContext";
 
@@ -37,6 +38,8 @@ export default function RootLayout({
           <CollectionProvider>
             {/* API Key Verifier runs at startup to check API keys */}
             <ApiKeyVerifier />
+            {/* Data Source Status shows whether we're using local data or GitHub */}
+            <DataSourceStatus />
             <Header />
             <main className="flex-grow container mx-auto px-4 py-6 page-container">
               {children}

--- a/src/components/DataSourceStatus.tsx
+++ b/src/components/DataSourceStatus.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { isUsingLocalData } from '@/lib/githubDataManager';
+
+/**
+ * Component that displays the current data source status
+ */
+export default function DataSourceStatus() {
+  const [usingLocal, setUsingLocal] = useState<boolean | null>(null);
+  const [showStatus, setShowStatus] = useState(false);
+
+  useEffect(() => {
+    // Check the data source status after a short delay
+    // to allow the data to be loaded
+    const timer = setTimeout(() => {
+      setUsingLocal(isUsingLocalData());
+      setShowStatus(true);
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!showStatus) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 bg-white dark:bg-gray-800 shadow-lg rounded-lg p-3 text-sm">
+      <div className="flex items-center space-x-2">
+        <div 
+          className={`w-3 h-3 rounded-full ${
+            usingLocal === null 
+              ? 'bg-gray-400' 
+              : usingLocal 
+                ? 'bg-green-500' 
+                : 'bg-yellow-500'
+          }`} 
+        />
+        <span>
+          {usingLocal === null 
+            ? 'Checking data source...' 
+            : usingLocal 
+              ? 'Using local data' 
+              : 'Using GitHub data'
+          }
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/githubDataManager.ts
+++ b/src/lib/githubDataManager.ts
@@ -13,6 +13,9 @@ const LOCAL_DATA_BASE_URL = '/data';
 const SETS_URL = `${LOCAL_DATA_BASE_URL}/sets/sets.json`;
 const CARDS_BASE_URL = `${LOCAL_DATA_BASE_URL}/cards`;
 
+// Flag to track if we're using local data or GitHub
+export let usingLocalData = false;
+
 // GitHub repository raw content URLs (fallback)
 const GITHUB_RAW_BASE_URL = 'https://raw.githubusercontent.com/PokemonTCG/pokemon-tcg-data/master';
 const GITHUB_SETS_URL = `${GITHUB_RAW_BASE_URL}/sets/en.json`;
@@ -41,12 +44,15 @@ export async function fetchSetsData(): Promise<any[]> {
       if (response.ok) {
         const data = await response.json();
         console.log(`Loaded ${data.length} sets from local data`);
+        usingLocalData = true;
         return data;
       }
     } catch (localError) {
       console.warn('Error fetching sets data from local data:', localError);
       // Continue to GitHub fallback
     }
+
+    usingLocalData = false;
 
     // Fallback to GitHub
     console.log('Fetching sets data from GitHub...');
@@ -78,12 +84,15 @@ export async function fetchCardsForSet(setId: string): Promise<any[]> {
       if (response.ok) {
         const data = await response.json();
         console.log(`Loaded ${data.length} cards for set ${setId} from local data`);
+        usingLocalData = true;
         return data;
       }
     } catch (localError) {
       console.warn(`Error fetching cards for set ${setId} from local data:`, localError);
       // Continue to GitHub fallback
     }
+
+    usingLocalData = false;
 
     // Fallback to GitHub
     console.log(`Fetching cards data for set ${setId} from GitHub...`);
@@ -293,6 +302,13 @@ export async function searchCardsByName(name: string): Promise<any[]> {
     console.error(`Error searching cards by name ${name}:`, error);
     throw error;
   }
+}
+
+/**
+ * Returns whether we're using local data or GitHub
+ */
+export function isUsingLocalData(): boolean {
+  return usingLocalData;
 }
 
 /**

--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,32 @@
 {
   "version": 2,
-  "buildCommand": "npm run build",
+  "buildCommand": "npm run download-all && npm run build",
   "installCommand": "npm install",
   "framework": "nextjs",
   "git": {
     "deploymentEnabled": {
       "main": true
     }
-  }
-} 
+  },
+  "regions": ["iad1"],
+  "headers": [
+    {
+      "source": "/data/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400, stale-while-revalidate=604800"
+        }
+      ]
+    },
+    {
+      "source": "/images/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Changes

This PR adds local data caching and download scripts to ensure that all data and images are initially loaded locally or cached. This will reduce API calls and improve performance.

### Key Changes

1. **Download Scripts**:
   - Added `download-pokemon-data.js` to download all sets and cards data from GitHub during build
   - Added `download-pokemon-images.js` to download and cache images for the most recent sets
   - Updated package.json scripts to run these downloads during build

2. **Vercel Configuration**:
   - Updated vercel.json to run the download scripts during deployment
   - Added caching headers for data and images

3. **Data Source Tracking**:
   - Enhanced the GitHub data manager to track whether we're using local data or GitHub
   - Added a DataSourceStatus component to display the current data source

### Benefits

- Reduced API calls to GitHub and the Pokemon TCG API
- Improved performance with local data access
- Better user experience with cached images
- Clear indication of the data source being used

These changes ensure that the application has all the necessary data and images available locally or cached, reducing the need for external API calls.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author