### PR TITLE
Fix UI issues: remove data source indicator and fix card detail infinite loop

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,6 @@ import "@/styles/mobile-optimizations.css";
 import Header from "@/components/Header";
 import MobileNavigation from "@/components/MobileNavigation";
 import ApiKeyVerifier from "@/components/ApiKeyVerifier";
-import DataSourceStatus from "@/components/DataSourceStatus";
 import { CollectionProvider } from "@/context/CollectionContext";
 import { AuthProvider } from "@/context/AuthContext";
 
@@ -38,8 +37,6 @@ export default function RootLayout({
           <CollectionProvider>
             {/* API Key Verifier runs at startup to check API keys */}
             <ApiKeyVerifier />
-            {/* Data Source Status shows whether we're using local data or GitHub */}
-            <DataSourceStatus />
             <Header />
             <main className="flex-grow container mx-auto px-4 py-6 page-container">
               {children}

--- a/src/components/SimpleCardDetailModal.tsx
+++ b/src/components/SimpleCardDetailModal.tsx
@@ -36,7 +36,7 @@ const SimpleCardDetailModal: React.FC<SimpleCardDetailModalProps> = ({ cardId, o
 
   const modalRef = useRef<HTMLDivElement>(null);
 
-  // Load card data when cardId changes
+  // Initialize selectedPrintId when cardId changes
   useEffect(() => {
     if (!cardId) {
       setCard(null);
@@ -45,10 +45,13 @@ const SimpleCardDetailModal: React.FC<SimpleCardDetailModalProps> = ({ cardId, o
       return;
     }
 
-    // Only initialize with cardId when first opening the modal
-    if (!selectedPrintId) {
-      setSelectedPrintId(cardId);
-    }
+    // Initialize with cardId when first opening the modal
+    setSelectedPrintId(cardId);
+  }, [cardId]);
+
+  // Load card data when selectedPrintId changes
+  useEffect(() => {
+    if (!selectedPrintId) return;
 
     let isMounted = true;
     const loadCardData = async () => {
@@ -58,13 +61,12 @@ const SimpleCardDetailModal: React.FC<SimpleCardDetailModalProps> = ({ cardId, o
       setPrints([]);
 
       try {
-        // Fetch card details for the currently selected print (or initial card)
-        const currentId = selectedPrintId || cardId;
-        console.log(`Loading card data for ID: ${currentId}`);
-        const fetchedInitialDetails = await fetchCardDetails(currentId);
+        // Fetch card details for the currently selected print
+        console.log(`Loading card data for ID: ${selectedPrintId}`);
+        const fetchedInitialDetails = await fetchCardDetails(selectedPrintId);
 
         if (!fetchedInitialDetails) {
-          throw new Error(`Card details not found for ID: ${currentId}`);
+          throw new Error(`Card details not found for ID: ${selectedPrintId}`);
         }
 
         if (!isMounted) return;
@@ -128,7 +130,7 @@ const SimpleCardDetailModal: React.FC<SimpleCardDetailModalProps> = ({ cardId, o
 
     loadCardData();
     return () => { isMounted = false; };
-  }, [cardId, selectedPrintId]);
+  }, [selectedPrintId]);
 
   // Safely find the selected print or fall back to the main card
   const displayedCard = prints.find(p => p && p.id === selectedPrintId) || card;


### PR DESCRIPTION
## Changes

This PR fixes two UI issues:

1. **Removed Data Source Indicator**: 
   - Removed the orange dot and "Using GitHub Data" message from the bottom right of the page
   - This indicator was confusing and not providing value to users

2. **Fixed Card Detail Infinite Loop**:
   - Fixed an issue in the SimpleCardDetailModal component where viewing a card would cause an infinite loop
   - The problem was in the useEffect dependency array that was watching selectedPrintId but also setting it inside the effect
   - Split the effect into two separate effects to properly handle initialization and data loading

These changes improve the user experience by removing a confusing UI element and fixing a critical bug that was preventing users from viewing card details.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author